### PR TITLE
Adding instructions to fetch the submodules when cloning the repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,8 @@ following commands:
 # Clone the wasm_game_of_life repository.
 git clone git@github.com:rustwasm/wasm_game_of_life.git
 
-# Initialize the local submodule configuration file.
-git submodule init
-
-# Fetch the appropriate submodule commit.
-git submodule update
+# Initialize and fetch the submodules.
+git submodule update --init
 ```
 
 This can also be performed with a single command using the

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ Chapter branches/submodules:
 * `chapter-three`: Speed ups to rendering and computing the next generation of
   cells.
 
+## Cloning the Repository
+
+In order to clone this repository and view the code for each chapter, you will
+need to initialize and update the submodules. This can be done using the
+following commands:
+
+```
+# Clone the wasm_game_of_life repository.
+git clone git@github.com:rustwasm/wasm_game_of_life.git
+
+# Initialize the local submodule configuration file.
+git submodule init
+
+# Fetch the appropriate submodule commit.
+git submodule update
+```
+
+This can also be performed with a single command using the
+`--recurse-submodules` option.
+
+```
+git clone --recurse-submodules git@github.com:rustwasm/wasm_game_of_life.git
+```
+
 ## Sending Pull Requests
 
 1. Checkout the branch for the first chapter that needs to be updated. Apply


### PR DESCRIPTION
People who are not familiar with how to use submodules in Git may have trouble cloning this repository. There are instructions for how to submit pull requests when changing chapters, this commit adds some information to the README that will help them fetch the chapters of the tutorial.