### PR TITLE
Use 2018 Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-game-of-life"
 version = "0.1.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -10,8 +11,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-cfg-if = "0.1.2"
 wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["console"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -21,12 +22,6 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-
-[dependencies.web-sys]
-version = "0.3"
-features = [
-  "console",
-]
 
 # [profile.release]
 # opt-level = 'z'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate cfg_if;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 mod utils;
 
 use std::fmt;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,10 @@
-use cfg_if::cfg_if;
-
-cfg_if! {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function to get better error messages if we ever panic.
-    if #[cfg(feature = "console_error_panic_hook")] {
-        extern crate console_error_panic_hook;
-        pub use self::console_error_panic_hook::set_once as set_panic_hook;
-    } else {
-        #[inline]
-        pub fn set_panic_hook() {}
-    }
+pub fn set_panic_hook() {
+  // When the `console_error_panic_hook` feature is enabled, we can call the
+  // `set_panic_hook` function at least once during initialization, and then
+  // we will get better error messages if our code ever panics.
+  //
+  // For more details see
+  // https://github.com/rustwasm/console_error_panic_hook#readme
+  #[cfg(feature = "console_error_panic_hook")]
+  console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
This PR uses 2018 Rust, which simplifies the code (no need to use `extern crate ...`), and removes `cfg_if` as it becomes unnecessary.