### PR TITLE
Remove default body margin to remove scrollbars

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -5,6 +5,7 @@
     <title>Hello wasm-pack!</title>
     <style>
      body {
+       margin: 0;
        position: absolute;
        top: 0;
        left: 0;


### PR DESCRIPTION
### Summary

The default css for rending the `<body>` makes the page scroll up and down. This will remove browser's default spacing to allow the `100%` property to not go outside of the browser window bounds.

https://rustwasm.github.io/docs/book/game-of-life/implementing.html#rendering-with-javascript