### PR TITLE
Use Universe's get_index method instead of defining same function again in javascript

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,6 @@ pub struct Universe {
 }
 
 impl Universe {
-    fn get_index(&self, row: u32, column: u32) -> usize {
-        (row * self.width + column) as usize
-    }
-
     /// Get the dead and alive values of the entire universe.
     pub fn get_cells(&self) -> &[Cell] {
         &self.cells
@@ -126,6 +122,10 @@ impl Universe {
 /// Public methods, exported to JavaScript.
 #[wasm_bindgen]
 impl Universe {
+    pub fn get_index(&self, row: u32, column: u32) -> usize {
+        (row * self.width + column) as usize
+    }
+
     pub fn tick(&mut self) {
         // let _timer = Timer::new("Universe::tick");
 

--- a/www/index.js
+++ b/www/index.js
@@ -121,10 +121,6 @@ const drawGrid = () => {
   ctx.stroke();
 };
 
-const getIndex = (row, column) => {
-  return row * width + column;
-};
-
 const drawCells = () => {
   const cellsPtr = universe.cells();
   const cells = new Uint8Array(memory.buffer, cellsPtr, width * height);
@@ -135,7 +131,7 @@ const drawCells = () => {
   ctx.fillStyle = ALIVE_COLOR;
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const idx = getIndex(row, col);
+      const idx = universe.get_index(row, col);
       if (cells[idx] !== Cell.Alive) {
         continue;
       }
@@ -153,7 +149,7 @@ const drawCells = () => {
   ctx.fillStyle = DEAD_COLOR;
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const idx = getIndex(row, col);
+      const idx = universe.get_index(row, col);
       if (cells[idx] !== Cell.Dead) {
         continue;
       }


### PR DESCRIPTION
Since we already implemented get_index method for Universe struct, why don't we just make it public and exported to javascript? 
